### PR TITLE
Fix CI and Date constraints

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -63,6 +63,12 @@ jobs:
         run: |
           composer create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard sylius "${{ matrix.sylius }}"
 
+      # Because the sylius-standard has a soft constraint
+      - name: Make sure to install the required version of Sylius
+        working-directory: ./sylius
+        run: |
+            composer require --no-install --no-scripts --no-progress sylius/sylius="${{ matrix.sylius }}"
+
       - name: Setup some requirements
         working-directory: ./sylius
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Setup PHP
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=1.10
+SYLIUS_VERSION=1.10.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
@@ -21,34 +21,26 @@ up: docker.up server.start ## Up the project (start docker, start symfony server
 stop: server.stop docker.stop ## Stop the project (stop docker, stop symfony server)
 down: server.stop docker.down ## Down the project (removes docker containers, stop symfony server)
 
-reset: docker.down ## Stop docker and remove dependencies
+reset: ## Stop docker and remove dependencies
+	${MAKE} docker.down || true
 	rm -rf ${APP_DIR}/node_modules ${APP_DIR}/yarn.lock
 	rm -rf ${APP_DIR}
 	rm -rf vendor composer.lock
 .PHONY: reset
 
-dependencies: vendor node_modules ## Setup the dependencies
+dependencies: composer.lock node_modules ## Setup the dependencies
 .PHONY: dependencies
 
 .php-version: .php-version.dist
-	cp .php-version.dist .php-version
+	rm -f .php-version
+	ln -s .php-version.dist .php-version
 
 php.ini: php.ini.dist
-	cp php.ini.dist php.ini
-
-vendor: composer.lock ## Install the PHP dependencies using composer
-ifdef GITHUB_ACTIONS
-	${COMPOSER} install --prefer-dist
-else
-	${COMPOSER} install --prefer-source
-endif
+	rm -f php.ini
+	ln -s php.ini.dist php.ini
 
 composer.lock: composer.json
-ifdef GITHUB_ACTIONS
-	${COMPOSER} update --prefer-dist
-else
-	${COMPOSER} update --prefer-source
-endif
+	${COMPOSER} install --no-scripts --no-plugins
 
 yarn.install: ${APP_DIR}/yarn.lock
 
@@ -70,22 +62,26 @@ ${APP_DIR}/node_modules: yarn.install
 application: .php-version php.ini ${APP_DIR} setup_application ${APP_DIR}/docker-compose.yaml
 
 ${APP_DIR}:
-	(${COMPOSER} create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="${SYLIUS_VERSION}" ${APP_DIR})
+	(${COMPOSER} create-project --no-interaction --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="~${SYLIUS_VERSION}" ${APP_DIR})
 
 setup_application:
 	rm -f ${APP_DIR}/yarn.lock
 	(cd ${APP_DIR} && ${COMPOSER} config repositories.plugin '{"type": "path", "url": "../../"}')
 	(cd ${APP_DIR} && ${COMPOSER} config extra.symfony.allow-contrib true)
-	(cd ${APP_DIR} && ${COMPOSER} require --no-scripts --no-progress --no-install --no-update monsieurbiz/${PLUGIN_NAME}="*@dev")
-	$(MAKE) apply_dist
+	(cd ${APP_DIR} && ${COMPOSER} config minimum-stability dev)
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
-	(cd ${APP_DIR} && ${COMPOSER} install)
+	(cd ${APP_DIR} && ${COMPOSER} install --no-interaction)
+	$(MAKE) apply_dist
+	(cd ${APP_DIR} && ${COMPOSER} require --no-progress monsieurbiz/${PLUGIN_NAME}="*@dev")
+	rm -rf ${APP_DIR}/var/cache
+
 
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml
 	rm -f ${APP_DIR}/docker-compose.yaml
-	cp docker-compose.yaml.dist ${APP_DIR}/docker-compose.yaml
+	ln -s ../../docker-compose.yaml.dist ${APP_DIR}/docker-compose.yaml
 .PHONY: ${APP_DIR}/docker-compose.yaml
 
 ${APP_DIR}/.php-version: .php-version
@@ -95,7 +91,15 @@ ${APP_DIR}/php.ini: php.ini
 	(cd ${APP_DIR} && ln -sf ../../php.ini)
 
 apply_dist:
-	cp -Rv dist/* ${APP_DIR} || true
+	ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))); \
+	for i in `cd dist && find . -type f`; do \
+		FILE_PATH=`echo $$i | sed 's|./||'`; \
+		FOLDER_PATH=`dirname $$FILE_PATH`; \
+		echo $$FILE_PATH; \
+		(cd ${APP_DIR} && rm -f $$FILE_PATH); \
+		(cd ${APP_DIR} && mkdir -p $$FOLDER_PATH); \
+		(cd ${APP_DIR} && ln -s $$ROOT_DIR/dist/$$FILE_PATH $$FILE_PATH); \
+    done
 
 ###
 ### TESTS
@@ -181,6 +185,11 @@ docker.down: ## Stop and remove the docker containers
 docker.logs: ## Logs the docker containers
 	cd ${APP_DIR} && ${COMPOSE} logs -f
 .PHONY: docker.logs
+
+docker.dc: ARGS=ps
+docker.dc: ## Run docker-compose command. Use ARGS="" to pass parameters to docker-compose.
+	cd ${APP_DIR} && ${COMPOSE} ${ARGS}
+.PHONY: docker.dc
 
 server.start: ## Run the local webserver using Symfony
 	${SYMFONY} local:server:start -d

--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,6 @@
         "symfony/web-profiler-bundle": "^4.4",
         "phpmd/phpmd": "@stable"
     },
-    "conflict": {
-        "doctrine/dbal": "^3"
-    },
     "prefer-stable": true,
     "autoload": {
         "psr-4": {

--- a/src/Event/CustomReportEvent.php
+++ b/src/Event/CustomReportEvent.php
@@ -16,7 +16,7 @@ namespace MonsieurBiz\SyliusSalesReportsPlugin\Event;
 use MonsieurBiz\SyliusSalesReportsPlugin\Exception\AlreadyExistsReport;
 use MonsieurBiz\SyliusSalesReportsPlugin\Exception\NotExistsReport;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class CustomReportEvent extends Event
 {

--- a/src/Form/Type/DateType.php
+++ b/src/Form/Type/DateType.php
@@ -29,7 +29,6 @@ class DateType extends AbstractType
                 'label' => 'monsieurbiz.sales_reports.form.date.label',
                 'required' => true,
                 'constraints' => [
-                    new Assert\Date([]),
                     new Assert\NotBlank([]),
                 ],
             ])

--- a/src/Form/Type/PeriodType.php
+++ b/src/Form/Type/PeriodType.php
@@ -29,7 +29,6 @@ class PeriodType extends AbstractType
                 'label' => 'monsieurbiz.sales_reports.form.from_date.label',
                 'required' => true,
                 'constraints' => [
-                    new Assert\Date([]),
                     new Assert\NotBlank([]),
                 ],
             ])
@@ -38,7 +37,6 @@ class PeriodType extends AbstractType
                 'label' => 'monsieurbiz.sales_reports.form.to_date.label',
                 'required' => true,
                 'constraints' => [
-                    new Assert\Date([]),
                     new Assert\NotBlank([]),
                 ],
             ])


### PR DESCRIPTION
- remove the temporary conflict with doctrine/dbal (fix in sylius)
- add node version in test workflow
- force the sylius version in recipe workflow
- improvements in makefile:
    - allow to install the latest minor version
    - fix the sylius version because the sylius-standard has a soft constraint
    - install sylius before the plugin is required
- replace the deprecated Event class (inspired by #11)
- remove the unnecessary date constraint, because the DateType always build a DateTime object (inspired by #11, thx @ehibes)