### PR TITLE
Reports improvements: display total row and remove shipping column when the value is always 0

### DIFF
--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -36,3 +36,4 @@ monsieurbiz:
             no_result: 'No result'
             option_name: 'Option name'
             option_value: 'Option value'
+            total: 'Total'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -36,3 +36,4 @@ monsieurbiz:
             no_result: 'Pas de résultat'
             option_name: 'Nom de l''option'
             option_value: 'Valeur de l''option'
+            total: 'Total'

--- a/src/Resources/translations/messages.nl.yml
+++ b/src/Resources/translations/messages.nl.yml
@@ -36,3 +36,4 @@ monsieurbiz:
             no_result: 'Geen resultaat'
             option_name: 'Optie naam'
             option_value: 'Optie waarde'
+            total: 'Totaal'

--- a/src/Resources/views/Admin/Report/_option.html.twig
+++ b/src/Resources/views/Admin/Report/_option.html.twig
@@ -8,7 +8,6 @@
         <th>{{ 'monsieurbiz.sales_reports.view.number_of_orders'|trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.promo_amount_without_tax' | trans }}</th>
-        <th>{{ 'monsieurbiz.sales_reports.view.shipping_amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.tax_amount' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.total_amount' | trans }}</th>
     </tr>
@@ -21,7 +20,6 @@
                 <td>{{ result.number_of_elements }}</td>
                 <td>{{ money.format(result.without_tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.without_tax_promo_total, channel.baseCurrency.code) }}</td>
-                <td>{{ money.format(result.without_tax_shipping_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.item_row_total, channel.baseCurrency.code) }}</td>
             </tr>

--- a/src/Resources/views/Admin/Report/_option.html.twig
+++ b/src/Resources/views/Admin/Report/_option.html.twig
@@ -1,5 +1,12 @@
 {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
 
+{% set number_of_elements_sum = 0 %}
+{% set without_tax_total_sum = 0 %}
+{% set without_tax_promo_total_sum = 0 %}
+{% set without_tax_shipping_total_sum = 0 %}
+{% set tax_total_sum = 0 %}
+{% set item_row_total_sum = 0 %}
+
 <h3>{{ 'monsieurbiz.sales_reports.ui.option_report'|trans }}</h3>
 <table class="ui celled table sortable">
     <thead>
@@ -15,6 +22,12 @@
     <tbody>
     {%  if product_option_sales_result|length > 0 %}
         {% for result in product_option_sales_result %}
+            {% set number_of_elements_sum = number_of_elements_sum + result.number_of_elements %}
+            {% set without_tax_total_sum = without_tax_total_sum + result.without_tax_total %}
+            {% set without_tax_promo_total_sum = without_tax_promo_total_sum + result.without_tax_promo_total %}
+            {% set without_tax_shipping_total_sum = without_tax_shipping_total_sum + result.without_tax_shipping_total %}
+            {% set tax_total_sum = tax_total_sum + result.tax_total %}
+            {% set item_row_total_sum = item_row_total_sum + result.item_row_total %}
             <tr>
                 <td>{{ result.option_label }}</td>
                 <td>{{ result.number_of_elements }}</td>
@@ -30,4 +43,16 @@
         </tr>
     {% endif %}
     </tbody>
+    {%  if product_option_sales_result|length > 0 %}
+        <tfoot>
+            <tr>
+                <th>{{ 'monsieurbiz.sales_reports.view.total'|trans }}</th>
+                <th>{{ number_of_elements_sum }}</th>
+                <th>{{ money.format(without_tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(without_tax_promo_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(item_row_total_sum, channel.baseCurrency.code) }}</th>
+            </tr>
+        </tfoot>
+    {% endif %}
 </table>

--- a/src/Resources/views/Admin/Report/_optionValue.html.twig
+++ b/src/Resources/views/Admin/Report/_optionValue.html.twig
@@ -9,7 +9,6 @@
         <th>{{ 'monsieurbiz.sales_reports.view.number_of_orders'|trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.promo_amount_without_tax' | trans }}</th>
-        <th>{{ 'monsieurbiz.sales_reports.view.shipping_amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.tax_amount' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.total_amount' | trans }}</th>
     </tr>
@@ -23,7 +22,6 @@
                 <td>{{ result.number_of_elements }}</td>
                 <td>{{ money.format(result.without_tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.without_tax_promo_total, channel.baseCurrency.code) }}</td>
-                <td>{{ money.format(result.without_tax_shipping_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.item_row_total, channel.baseCurrency.code) }}</td>
             </tr>

--- a/src/Resources/views/Admin/Report/_optionValue.html.twig
+++ b/src/Resources/views/Admin/Report/_optionValue.html.twig
@@ -1,5 +1,12 @@
 {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
 
+{% set number_of_elements_sum = 0 %}
+{% set without_tax_total_sum = 0 %}
+{% set without_tax_promo_total_sum = 0 %}
+{% set without_tax_shipping_total_sum = 0 %}
+{% set tax_total_sum = 0 %}
+{% set item_row_total_sum = 0 %}
+
 <h3>{{ 'monsieurbiz.sales_reports.ui.option_value_report'|trans }}</h3>
 <table class="ui celled table sortable">
     <thead>
@@ -16,6 +23,12 @@
     <tbody>
     {%  if product_option_value_sales_result|length > 0 %}
         {% for result in product_option_value_sales_result %}
+            {% set number_of_elements_sum = number_of_elements_sum + result.number_of_elements %}
+            {% set without_tax_total_sum = without_tax_total_sum + result.without_tax_total %}
+            {% set without_tax_promo_total_sum = without_tax_promo_total_sum + result.without_tax_promo_total %}
+            {% set without_tax_shipping_total_sum = without_tax_shipping_total_sum + result.without_tax_shipping_total %}
+            {% set tax_total_sum = tax_total_sum + result.tax_total %}
+            {% set item_row_total_sum = item_row_total_sum + result.item_row_total %}
             <tr>
                 <td>{{ result.option_label }}</td>
                 <td>{{ result.option_value_label }}</td>
@@ -32,4 +45,16 @@
         </tr>
     {% endif %}
     </tbody>
+    {%  if product_option_value_sales_result|length > 0 %}
+        <tfoot>
+            <tr>
+                <th colspan="2">{{ 'monsieurbiz.sales_reports.view.total'|trans }}</th>
+                <th>{{ number_of_elements_sum }}</th>
+                <th>{{ money.format(without_tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(without_tax_promo_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(item_row_total_sum, channel.baseCurrency.code) }}</th>
+            </tr>
+        </tfoot>
+    {% endif %}
 </table>

--- a/src/Resources/views/Admin/Report/_product.html.twig
+++ b/src/Resources/views/Admin/Report/_product.html.twig
@@ -1,5 +1,12 @@
 {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
 
+{% set number_of_elements_sum = 0 %}
+{% set without_tax_total_sum = 0 %}
+{% set without_tax_promo_total_sum = 0 %}
+{% set without_tax_shipping_total_sum = 0 %}
+{% set tax_total_sum = 0 %}
+{% set item_row_total_sum = 0 %}
+
 <h3>{{ 'monsieurbiz.sales_reports.ui.product_report'|trans }}</h3>
 <table class="ui celled table sortable">
     <thead>
@@ -15,6 +22,12 @@
     <tbody>
     {%  if product_sales_result|length > 0 %}
         {% for result in product_sales_result %}
+            {% set number_of_elements_sum = number_of_elements_sum + result.number_of_elements %}
+            {% set without_tax_total_sum = without_tax_total_sum + result.without_tax_total %}
+            {% set without_tax_promo_total_sum = without_tax_promo_total_sum + result.without_tax_promo_total %}
+            {% set without_tax_shipping_total_sum = without_tax_shipping_total_sum + result.without_tax_shipping_total %}
+            {% set tax_total_sum = tax_total_sum + result.tax_total %}
+            {% set item_row_total_sum = item_row_total_sum + result.item_row_total %}
             <tr>
                 <td>{{ result.product_name }}</td>
                 <td>{{ result.number_of_elements }}</td>
@@ -30,4 +43,16 @@
         </tr>
     {% endif %}
     </tbody>
+    {%  if product_sales_result|length > 0 %}
+        <tfoot>
+            <tr>
+                <th>{{ 'monsieurbiz.sales_reports.view.total'|trans }}</th>
+                <th>{{ number_of_elements_sum }}</th>
+                <th>{{ money.format(without_tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(without_tax_promo_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(item_row_total_sum, channel.baseCurrency.code) }}</th>
+            </tr>
+        </tfoot>
+    {% endif %}
 </table>

--- a/src/Resources/views/Admin/Report/_product.html.twig
+++ b/src/Resources/views/Admin/Report/_product.html.twig
@@ -8,7 +8,6 @@
         <th>{{ 'monsieurbiz.sales_reports.view.number_of_orders'|trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.promo_amount_without_tax' | trans }}</th>
-        <th>{{ 'monsieurbiz.sales_reports.view.shipping_amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.tax_amount' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.total_amount' | trans }}</th>
     </tr>
@@ -21,7 +20,6 @@
                 <td>{{ result.number_of_elements }}</td>
                 <td>{{ money.format(result.without_tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.without_tax_promo_total, channel.baseCurrency.code) }}</td>
-                <td>{{ money.format(result.without_tax_shipping_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.item_row_total, channel.baseCurrency.code) }}</td>
             </tr>

--- a/src/Resources/views/Admin/Report/_productVariant.html.twig
+++ b/src/Resources/views/Admin/Report/_productVariant.html.twig
@@ -8,7 +8,6 @@
         <th>{{ 'monsieurbiz.sales_reports.view.number_of_orders'|trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.promo_amount_without_tax' | trans }}</th>
-        <th>{{ 'monsieurbiz.sales_reports.view.shipping_amount_without_tax' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.tax_amount' | trans }}</th>
         <th>{{ 'monsieurbiz.sales_reports.view.total_amount' | trans }}</th>
     </tr>
@@ -21,7 +20,6 @@
                 <td>{{ result.number_of_elements }}</td>
                 <td>{{ money.format(result.without_tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.without_tax_promo_total, channel.baseCurrency.code) }}</td>
-                <td>{{ money.format(result.without_tax_shipping_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.tax_total, channel.baseCurrency.code) }}</td>
                 <td>{{ money.format(result.item_row_total, channel.baseCurrency.code) }}</td>
             </tr>

--- a/src/Resources/views/Admin/Report/_productVariant.html.twig
+++ b/src/Resources/views/Admin/Report/_productVariant.html.twig
@@ -1,5 +1,12 @@
 {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
 
+{% set number_of_elements_sum = 0 %}
+{% set without_tax_total_sum = 0 %}
+{% set without_tax_promo_total_sum = 0 %}
+{% set without_tax_shipping_total_sum = 0 %}
+{% set tax_total_sum = 0 %}
+{% set item_row_total_sum = 0 %}
+
 <h3>{{ 'monsieurbiz.sales_reports.ui.product_variant_report'|trans }}</h3>
 <table class="ui celled table sortable">
     <thead>
@@ -15,6 +22,12 @@
     <tbody>
     {%  if product_variant_sales_result|length > 0 %}
         {% for result in product_variant_sales_result %}
+            {% set number_of_elements_sum = number_of_elements_sum + result.number_of_elements %}
+            {% set without_tax_total_sum = without_tax_total_sum + result.without_tax_total %}
+            {% set without_tax_promo_total_sum = without_tax_promo_total_sum + result.without_tax_promo_total %}
+            {% set without_tax_shipping_total_sum = without_tax_shipping_total_sum + result.without_tax_shipping_total %}
+            {% set tax_total_sum = tax_total_sum + result.tax_total %}
+            {% set item_row_total_sum = item_row_total_sum + result.item_row_total %}
             <tr>
                 <td>{{ result.variant_name }}</td>
                 <td>{{ result.number_of_elements }}</td>
@@ -30,4 +43,16 @@
         </tr>
     {% endif %}
     </tbody>
+    {%  if product_variant_sales_result|length > 0 %}
+        <tfoot>
+            <tr>
+                <th>{{ 'monsieurbiz.sales_reports.view.total'|trans }}</th>
+                <th>{{ number_of_elements_sum }}</th>
+                <th>{{ money.format(without_tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(without_tax_promo_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(tax_total_sum, channel.baseCurrency.code) }}</th>
+                <th>{{ money.format(item_row_total_sum, channel.baseCurrency.code) }}</th>
+            </tr>
+        </tfoot>
+    {% endif %}
 </table>


### PR DESCRIPTION
Summary:

- Remove the shipping amount column for report based on item values (like product, variant and option reports), because the amount is based on order
- Display a total row after some reports

