### PR TITLE
Add German translations for sales reports

### DIFF
--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,39 @@
+monsieurbiz:
+    sales_reports:
+        ui:
+            title: 'Umsatzberichte'
+            subtitle: 'Sehen Sie Ihre Umsatzberichte an'
+            day_report: 'Tagesbericht'
+            day_report_for: 'Tagesbericht für den %date% für %channel%'
+            period_report: 'Zeitraum-Bericht'
+            period_report_for: 'Zeitraum-Bericht vom %from% bis %to% für %channel%'
+            global_report: 'Gesamtbericht'
+            average_report: 'Durchschnittsbericht'
+            number_of_orders: 'Anzahl der Bestellungen:'
+            product_report: 'Produktbericht'
+            product_variant_report: 'Produktvariantenbericht'
+            option_report: 'Optionsbericht'
+            option_value_report: 'Optionswert-Bericht'
+            statistics: 'Statistiken'
+        form:
+            channel:
+                label: 'Kanal'
+            date:
+                label: 'Bestimmter Tag'
+            from_date:
+                label: 'Von'
+            to_date:
+                label: 'Bis'
+        view:
+            amount_without_tax: 'Betrag ohne Steuern'
+            promo_amount_without_tax: 'Aktionsbetrag ohne Steuern'
+            shipping_amount_without_tax: 'Versandbetrag ohne Steuern'
+            tax_amount: 'Steuerbetrag'
+            total_amount: 'Gesamtbetrag mit Steuern'
+            number_of_orders: 'Anzahl der Bestellungen'
+            product_name: 'Produktname'
+            product_variant_name: 'Produktvariantenname'
+            no_result: 'Kein Ergebnis'
+            option_name: 'Optionsname'
+            option_value: 'Optionswert'
+            total: 'Gesamt'


### PR DESCRIPTION
## Summary

This PR adds German translations for the sales reports user interface.

## Changes

- Created a new translation file: `messages.de.yml`
- Added translations for the sales reports, including titles, subtitles, labels, and report-related texts.

## Rationale

This addition enhances the usability of the sales reports for German-speaking users, ensuring they can access the same functionalities in their preferred language.
